### PR TITLE
Add missing facets/filters in Get-UMSDevice

### DIFF
--- a/PSIGEL/Private/New-UMSFilterString.ps1
+++ b/PSIGEL/Private/New-UMSFilterString.ps1
@@ -15,13 +15,19 @@ function New-UMSFilterString
 
   .EXAMPLE
   New-UMSFilterString -Filter 'children'
+  
+  .EXAMPLE
+  New-UMSFilterString -Filter 'deviceattributes'
+  
+  .EXAMPLE
+  New-UMSFilterString -Filter 'networkadapters'
 
   #>
 
   [cmdletbinding(SupportsShouldProcess, ConfirmImpact = 'Low')]
   param (
     [Parameter(Mandatory)]
-    [ValidateSet('short', 'details', 'online', 'shadow', 'children')]
+    [ValidateSet('short', 'details', 'online', 'shadow', 'children', 'deviceattributes', 'netwokadapters')]
     [String]
     $Filter
   )

--- a/PSIGEL/Private/New-UMSFilterString.ps1
+++ b/PSIGEL/Private/New-UMSFilterString.ps1
@@ -27,7 +27,7 @@ function New-UMSFilterString
   [cmdletbinding(SupportsShouldProcess, ConfirmImpact = 'Low')]
   param (
     [Parameter(Mandatory)]
-    [ValidateSet('short', 'details', 'online', 'shadow', 'children', 'deviceattributes', 'netwokadapters')]
+    [ValidateSet('short', 'details', 'online', 'shadow', 'children', 'deviceattributes', 'networkadapters')]
     [String]
     $Filter
   )

--- a/PSIGEL/Public/Get-UMSDevice.ps1
+++ b/PSIGEL/Public/Get-UMSDevice.ps1
@@ -147,16 +147,40 @@
         }
         deviceattributes
         {
-          $Properties += [ordered]@{
-            #TODO
+          $AttributeCount = 0
+          if ($APIObject.deviceAttributes) {
+            $Properties.Add('DeviceAttributes', $APIObject.deviceAttributes)
+            foreach ($DeviceAttribute in $APIObject.deviceAttributes) {
+              $Properties.Add(-join('DeviceAttribute-', $([String]$DeviceAttribute.identifier), '-Type'), [String]$DeviceAttribute.type)
+              $Properties.Add(-join('DeviceAttribute-', $([String]$DeviceAttribute.identifier), '-Name'), [String]$DeviceAttribute.name)
+              $Properties.Add(-join('DeviceAttribute-', $([String]$DeviceAttribute.identifier), '-Value'), [String]$DeviceAttribute.value)
+              $Properties.Add(-join('DeviceAttribute-', $([String]$DeviceAttribute.identifier), '-Identifier'), [String]$DeviceAttribute.identifier)
+              if ([String]$DeviceAttribute.type -eq 'range') {
+                $Properties.Add(-join('DeviceAttribute-', $([String]$DeviceAttribute.identifier), '-AllowedValues'), [String]$DeviceAttribute.allowedValues)
+              }
+              $AttributeCount += 1
+            }
+          } else {
+            $Properties.Add('DeviceAttributes', '')
           }
+          $Properties.Add('DeviceAttributeCount', [Int]$AttributeCount)
         }
         networkadapters
         {
-          
-          $Properties += [ordered]@{
-            #TODO
+          $AdapterCount = 0
+          if ($APIObject.networkAdapters) {
+            $Properties.Add('NetworkAdapters', $APIObject.networkAdapters)
+            foreach ($NetworkAdapter in $APIObject.networkAdapters) {
+              $Properties.Add(-join('NetworkAdapter', $($AdapterCount), '-Type'), [String]$NetworkAdapter.type)
+              $Properties.Add(-join('NetworkAdapter', $($AdapterCount), '-Mac'), [String]$NetworkAdapter.mac)
+              $Properties.Add(-join('NetworkAdapter', $($AdapterCount), '-Name'), [String]$NetworkAdapter.name)
+              $Properties.Add(-join('NetworkAdapter', $($AdapterCount), '-State'), [String]$NetworkAdapter.state)
+              $AdapterCount += 1
+            }
+          } else {
+            $Properties.Add('NetworkAdapters', '')
           }
+          $Properties.Add('NetworkAdapterCount', [Int]$AdapterCount)
         }
       }
       New-Object psobject -Property $Properties

--- a/PSIGEL/Public/Get-UMSDevice.ps1
+++ b/PSIGEL/Public/Get-UMSDevice.ps1
@@ -167,7 +167,8 @@
                   $AttributeProperties.Add('Value', [datetime]$DeviceAttribute.value)
                 }
               }
-              $Properties.Add(-join('DeviceAttribute-', $([String]$DeviceAttribute.identifier)), $AttributeProperties)
+              $AttributePropertiesObject = New-Object PSObject -Property $AttributeProperties
+              $Properties.Add(-join('DeviceAttribute-', $([String]$DeviceAttribute.identifier)), $AttributePropertiesObject)
               
               $Properties.Add(-join('DeviceAttribute-', $([String]$DeviceAttribute.identifier), '-Identifier'), [String]$DeviceAttribute.identifier)
               $Properties.Add(-join('DeviceAttribute-', $([String]$DeviceAttribute.identifier), '-Name'), [String]$DeviceAttribute.name)

--- a/PSIGEL/Public/Get-UMSDevice.ps1
+++ b/PSIGEL/Public/Get-UMSDevice.ps1
@@ -189,7 +189,7 @@
                 'State' = [String]$NetworkAdapter.state
               }
               $AdapterPropertiesObject = New-Object PSObject -Property $AdapterProperties
-              $Properties.Add(-join('NetworkAdapter-', $($($AdapterCount)), $AttributePropertiesObject)
+              $Properties.Add(-join('NetworkAdapter-', $($AdapterCount)), $AttributePropertiesObject)
               $AdapterCount += 1
             }
           } else {

--- a/PSIGEL/Public/Get-UMSDevice.ps1
+++ b/PSIGEL/Public/Get-UMSDevice.ps1
@@ -169,14 +169,6 @@
               }
               $AttributePropertiesObject = New-Object PSObject -Property $AttributeProperties
               $Properties.Add(-join('DeviceAttribute-', $([String]$DeviceAttribute.identifier)), $AttributePropertiesObject)
-              
-              $Properties.Add(-join('DeviceAttribute-', $([String]$DeviceAttribute.identifier), '-Identifier'), [String]$DeviceAttribute.identifier)
-              $Properties.Add(-join('DeviceAttribute-', $([String]$DeviceAttribute.identifier), '-Name'), [String]$DeviceAttribute.name)
-              $Properties.Add(-join('DeviceAttribute-', $([String]$DeviceAttribute.identifier), '-Type'), [String]$DeviceAttribute.type)
-              $Properties.Add(-join('DeviceAttribute-', $([String]$DeviceAttribute.identifier), '-Value'), [String]$DeviceAttribute.value)
-              if ([String]$DeviceAttribute.type -eq 'range') {
-                $Properties.Add(-join('DeviceAttribute-', $([String]$DeviceAttribute.identifier), '-AllowedValues'), $DeviceAttribute.allowedValues)
-              }
               $AttributeCount += 1
             }
           } else {
@@ -190,10 +182,14 @@
           if ($APIObject.networkAdapters) {
             $Properties.Add('NetworkAdapters', $APIObject.networkAdapters)
             foreach ($NetworkAdapter in $APIObject.networkAdapters) {
-              $Properties.Add(-join('NetworkAdapter', $($AdapterCount), '-Type'), [String]$NetworkAdapter.type)
-              $Properties.Add(-join('NetworkAdapter', $($AdapterCount), '-Mac'), [String]$NetworkAdapter.mac)
-              $Properties.Add(-join('NetworkAdapter', $($AdapterCount), '-Name'), [String]$NetworkAdapter.name)
-              $Properties.Add(-join('NetworkAdapter', $($AdapterCount), '-State'), [String]$NetworkAdapter.state)
+              $AdapterProperties = [ordered]@{
+                'Name' = [String]$NetworkAdapter.name
+                'Type' = [String]$NetworkAdapter.type
+                'Mac' = [String]$NetworkAdapter.mac
+                'State' = [String]$NetworkAdapter.state
+              }
+              $AdapterPropertiesObject = New-Object PSObject -Property $AdapterProperties
+              $Properties.Add(-join('NetworkAdapter-', $($($AdapterCount)), $AttributePropertiesObject)
               $AdapterCount += 1
             }
           } else {

--- a/PSIGEL/Public/Get-UMSDevice.ps1
+++ b/PSIGEL/Public/Get-UMSDevice.ps1
@@ -151,11 +151,28 @@
           if ($APIObject.deviceAttributes) {
             $Properties.Add('DeviceAttributes', $APIObject.deviceAttributes)
             foreach ($DeviceAttribute in $APIObject.deviceAttributes) {
+              $AttributeProperties = [ordered]@{
+                'Identifier' = [String]$DeviceAttribute.identifier
+                'Name' = [String]$DeviceAttribute.name
+                'Type' = [String]$DeviceAttribute.type
+              }
+              switch ([String]$DeviceAttribute.type) {
+                range
+                {
+                  $AttributeProperties.Add('Value', [String]$DeviceAttribute.value)
+                  $AttributeProperties.Add('AllowedValues', $DeviceAttribute.allowedValues)
+                }
+                date
+                {
+                  $AttributeProperties.Add('Value', [datetime]$DeviceAttribute.value)
+                }
+              }
+              $Properties.Add(-join('DeviceAttribute-', $([String]$DeviceAttribute.identifier)), $AttributeProperties)
+              
               $Properties.Add(-join('DeviceAttribute-', $([String]$DeviceAttribute.identifier), '-Identifier'), [String]$DeviceAttribute.identifier)
               $Properties.Add(-join('DeviceAttribute-', $([String]$DeviceAttribute.identifier), '-Name'), [String]$DeviceAttribute.name)
               $Properties.Add(-join('DeviceAttribute-', $([String]$DeviceAttribute.identifier), '-Type'), [String]$DeviceAttribute.type)
               $Properties.Add(-join('DeviceAttribute-', $([String]$DeviceAttribute.identifier), '-Value'), [String]$DeviceAttribute.value)
-              
               if ([String]$DeviceAttribute.type -eq 'range') {
                 $Properties.Add(-join('DeviceAttribute-', $([String]$DeviceAttribute.identifier), '-AllowedValues'), $DeviceAttribute.allowedValues)
               }

--- a/PSIGEL/Public/Get-UMSDevice.ps1
+++ b/PSIGEL/Public/Get-UMSDevice.ps1
@@ -151,10 +151,11 @@
           if ($APIObject.deviceAttributes) {
             $Properties.Add('DeviceAttributes', $APIObject.deviceAttributes)
             foreach ($DeviceAttribute in $APIObject.deviceAttributes) {
-              $Properties.Add(-join('DeviceAttribute-', $([String]$DeviceAttribute.identifier), '-Type'), [String]$DeviceAttribute.type)
-              $Properties.Add(-join('DeviceAttribute-', $([String]$DeviceAttribute.identifier), '-Name'), [String]$DeviceAttribute.name)
-              $Properties.Add(-join('DeviceAttribute-', $([String]$DeviceAttribute.identifier), '-Value'), [String]$DeviceAttribute.value)
               $Properties.Add(-join('DeviceAttribute-', $([String]$DeviceAttribute.identifier), '-Identifier'), [String]$DeviceAttribute.identifier)
+              $Properties.Add(-join('DeviceAttribute-', $([String]$DeviceAttribute.identifier), '-Name'), [String]$DeviceAttribute.name)
+              $Properties.Add(-join('DeviceAttribute-', $([String]$DeviceAttribute.identifier), '-Type'), [String]$DeviceAttribute.type)
+              $Properties.Add(-join('DeviceAttribute-', $([String]$DeviceAttribute.identifier), '-Value'), [String]$DeviceAttribute.value)
+              
               if ([String]$DeviceAttribute.type -eq 'range') {
                 $Properties.Add(-join('DeviceAttribute-', $([String]$DeviceAttribute.identifier), '-AllowedValues'), $DeviceAttribute.allowedValues)
               }

--- a/PSIGEL/Public/Get-UMSDevice.ps1
+++ b/PSIGEL/Public/Get-UMSDevice.ps1
@@ -156,7 +156,7 @@
               $Properties.Add(-join('DeviceAttribute-', $([String]$DeviceAttribute.identifier), '-Value'), [String]$DeviceAttribute.value)
               $Properties.Add(-join('DeviceAttribute-', $([String]$DeviceAttribute.identifier), '-Identifier'), [String]$DeviceAttribute.identifier)
               if ([String]$DeviceAttribute.type -eq 'range') {
-                $Properties.Add(-join('DeviceAttribute-', $([String]$DeviceAttribute.identifier), '-AllowedValues'), [String]$DeviceAttribute.allowedValues)
+                $Properties.Add(-join('DeviceAttribute-', $([String]$DeviceAttribute.identifier), '-AllowedValues'), $DeviceAttribute.allowedValues)
               }
               $AttributeCount += 1
             }

--- a/PSIGEL/Public/Get-UMSDevice.ps1
+++ b/PSIGEL/Public/Get-UMSDevice.ps1
@@ -168,7 +168,7 @@
                 }
               }
               $AttributePropertiesObject = New-Object PSObject -Property $AttributeProperties
-              $Properties.Add(-join('DeviceAttribute-', $([String]$DeviceAttribute.identifier)), $AttributePropertiesObject)
+              $Properties.Add(-join('DeviceAttribute_', $([String]$DeviceAttribute.identifier)), $AttributePropertiesObject)
               $AttributeCount += 1
             }
           } else {

--- a/PSIGEL/Public/Get-UMSDevice.ps1
+++ b/PSIGEL/Public/Get-UMSDevice.ps1
@@ -22,7 +22,7 @@
     [Parameter(Mandatory)]
     $WebSession,
 
-    [ValidateSet('short', 'details', 'online', 'shadow')]
+    [ValidateSet('short', 'details', 'online', 'shadow', 'deviceattributes', 'networkadapters')]
     [String]
     $Filter = 'short',
 
@@ -143,6 +143,19 @@
           else
           {
             $Properties.Add('BiosDate', '')
+          }
+        }
+        deviceattributes
+        {
+          $Properties += [ordered]@{
+            #TODO
+          }
+        }
+        networkadapters
+        {
+          
+          $Properties += [ordered]@{
+            #TODO
           }
         }
       }

--- a/PSIGEL/Public/Get-UMSDevice.ps1
+++ b/PSIGEL/Public/Get-UMSDevice.ps1
@@ -189,7 +189,7 @@
                 'State' = [String]$NetworkAdapter.state
               }
               $AdapterPropertiesObject = New-Object PSObject -Property $AdapterProperties
-              $Properties.Add(-join('NetworkAdapter-', $($AdapterCount)), $AttributePropertiesObject)
+              $Properties.Add(-join('NetworkAdapter', $($AdapterCount)), $AdapterPropertiesObject)
               $AdapterCount += 1
             }
           } else {

--- a/PSIGEL/Public/Get-UMSDevice.ps1
+++ b/PSIGEL/Public/Get-UMSDevice.ps1
@@ -159,12 +159,20 @@
               switch ([String]$DeviceAttribute.type) {
                 range
                 {
-                  $AttributeProperties.Add('Value', [String]$DeviceAttribute.value)
+                  $AttributeProperties.Add('Value', $DeviceAttribute.value)
                   $AttributeProperties.Add('AllowedValues', $DeviceAttribute.allowedValues)
                 }
                 date
                 {
                   $AttributeProperties.Add('Value', [datetime]$DeviceAttribute.value)
+                }
+                string
+                {
+                  $AttributeProperties.Add('Value', [Single]$DeviceAttribute.value)
+                }
+                number
+                {
+                  $AttributeProperties.Add('Value', [String]$DeviceAttribute.value)
                 }
               }
               $AttributePropertiesObject = New-Object PSObject -Property $AttributeProperties

--- a/PSIGEL/en-US/PSIGEL-help.xml
+++ b/PSIGEL/en-US/PSIGEL-help.xml
@@ -52,6 +52,8 @@
             <command:parameterValue required="false" command:variableLength="false">details</command:parameterValue>
             <command:parameterValue required="false" command:variableLength="false">online</command:parameterValue>
             <command:parameterValue required="false" command:variableLength="false">shadow</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">deviceattributes</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">networkadapters</command:parameterValue>
           </command:parameterValueGroup>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>


### PR DESCRIPTION
Hello there,

i have added the currently missing facets/filters "networkadapters" and "deviceattibutes" to Get-UMSDevice.ps1, New-UMSFilterString.ps1 and PSIGEL-help.xml

**Example Output:**
![grafik](https://user-images.githubusercontent.com/29387023/171863049-f73e9ebd-b138-49e0-9c45-4f2107640f58.png)

The PowerShell-User can either use the "raw" Data from the UMS via the "DeviceAttributes" and "NetworkAdapters" Properties
or they can use the per DeviceAttribute/NetworkAdapter Properties.
Generally I would not have a problem removing any of the two options but i can see valid use cases (simplicity/etc.) for both so i left both in.
Additionally i added a DeviceAttribute/NetworkAdapter-Counter to allow easy Filtering for Devices with a certain amount of those without the User having to loop through every objects Properties to count himself.

**Other relevant Screenshots:**
![grafik](https://user-images.githubusercontent.com/29387023/171864224-87992c32-f1e7-49e6-b5db-314bb1759973.png)
![grafik](https://user-images.githubusercontent.com/29387023/171864855-d4e4cc7d-8e0e-4ea1-a0a6-85876a9d03ee.png)
![grafik](https://user-images.githubusercontent.com/29387023/171865158-72e4a9a3-047a-46a7-b183-20013c010cef.png)